### PR TITLE
Miscellany and upkeep

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.12.0-rc.0-otp-24
+erlang 24.0-rc3

--- a/lib/passive_support/base/integer.ex
+++ b/lib/passive_support/base/integer.ex
@@ -50,7 +50,9 @@ defmodule PassiveSupport.Integer do
   import Bitwise
   # Derived from https://stackoverflow.com/questions/32024156/how-do-i-raise-a-number-to-a-power-in-elixir#answer-32030190
   @doc ~S"""
-  Arbitrary-precision exponentiation
+  Arbitrary-precision exponentiation.
+
+  Will be deprecated by Elixir [v1.12.0](https://github.com/elixir-lang/elixir/commit/b11a119f52c882e2ab0f35040ef4a4b4e9d23065)
 
   ## Examples
 

--- a/lib/passive_support/base/range.ex
+++ b/lib/passive_support/base/range.ex
@@ -1,6 +1,25 @@
 defmodule PassiveSupport.Range do
   @moduledoc """
-  Helper functions for using ranges
+  Helper functions for working with ranges.
+
+  Ranges have some interesting characteristics in Elixir. A range literal
+  is the language's simplest representation of a Stream; the use case for
+  them is rather limited compared to other languages; and as of version 1.12.0,
+  it is the first data type in Elixir to make use of a ternary operator (`..///3`)
+
+  All of this can mean exactly one thing: Ranges are for lovers. And by
+  virtue of that fact, this library maintainer's personal soft spot for
+  the data type has to be categorical proof that he is, in fact, a lover.
+
+  This module defines a number of functions that help in determining the
+  characteristics of a range, especially in terms of another range, as
+  well as some functions that aid in manipulating ranges for various
+  use cases — the existence of all of which, as of yet, are unproven.
+  Nevertheless, if any of these hypothetical workflows are eventually
+  found to be extant, these functions will all doubtlessly prove invaluable
+  to whatever intrepid, frontier programmer is brave enough to address
+  the challenging burdens, somehow lightened by these desperate grasps
+  for relevance.
   """
 
   @doc ~S"""
@@ -35,6 +54,7 @@ defmodule PassiveSupport.Range do
       iex> includes?(5..1, 4..2)
       true
   """
+  @doc since: "0.1.0"
   @spec includes?(Range.t, any) :: boolean
   def includes?(range, other_start..other_finish), do:
     includes?(range, other_start) and includes?(range, other_finish)
@@ -73,6 +93,7 @@ defmodule PassiveSupport.Range do
       iex> overlaps?(6..4, 5..1)
       true
   """
+  @doc since: "0.1.0"
   @spec overlaps?(Range.t, Range.t) :: boolean
   def overlaps?(start_1..finish_1, start_a..finish_a)
       when ((start_1 > finish_1) and (start_a < finish_a))
@@ -104,6 +125,7 @@ defmodule PassiveSupport.Range do
       iex> adjacent?(10..6, 1..5)
       false
   """
+  @doc since: "0.1.0"
   @spec adjacent?(Range.t, Range.t) :: boolean
   def adjacent?(start_1..finish_1, start_b..finish_b) when start_1 > finish_1, do:
     finish_1-1 == start_b or finish_b-1 == start_1
@@ -131,6 +153,7 @@ defmodule PassiveSupport.Range do
       iex> join(1..5, 10..5)
       ** (ArgumentError) Cannot join 1..5 and 10..5
   """
+  @doc since: "0.1.0"
   @spec join(Range.t, Range.t) :: Range.t
   def join(range_1, range_a) do
     case overlaps?(range_1, range_a) or adjacent?(range_1, range_a) do
@@ -154,6 +177,7 @@ defmodule PassiveSupport.Range do
       iex> size(5..0)
       6
   """
+  @doc since: "0.1.0"
   @spec size(Range.t) :: integer
   def size(start..start), do:
     1
@@ -174,6 +198,7 @@ defmodule PassiveSupport.Range do
       iex> first(5..0)
       5
   """
+  @doc since: "0.1.0"
   @spec first(Range.t) :: integer
   def first(start.._finish), do:
     start
@@ -188,6 +213,7 @@ defmodule PassiveSupport.Range do
       iex> last(5..0)
       0
   """
+  @doc since: "0.1.0"
   @spec last(Range.t) :: integer
   def last(_start..finish), do:
     finish
@@ -202,6 +228,7 @@ defmodule PassiveSupport.Range do
       iex> max(5..0)
       5
   """
+  @doc since: "0.1.0"
   def max(start..finish) when finish < start, do:
     start
   def max(_start..finish), do:
@@ -217,6 +244,7 @@ defmodule PassiveSupport.Range do
       iex> min(5..0)
       0
   """
+  @doc since: "0.1.0"
   def min(start..finish) when finish < start, do:
     finish
   def min(start.._finish), do:
@@ -233,6 +261,7 @@ defmodule PassiveSupport.Range do
       iex> next_page(10..1)
       0..-9
   """
+  @doc since: "0.1.0"
   @spec next_page(Range.t) :: Range.t
   def next_page(start..finish) when finish < start, do:
     finish-1..finish-(1+start-finish)
@@ -250,6 +279,7 @@ defmodule PassiveSupport.Range do
       iex> prev_page(10..1)
       20..11
   """
+  @doc since: "0.1.0"
   @spec prev_page(Range.t) :: Range.t
   def prev_page(start..finish) when finish < start, do:
     (start+(1+start-finish))..finish+(1+start-finish)

--- a/lib/passive_support/base/stream.ex
+++ b/lib/passive_support/base/stream.ex
@@ -38,7 +38,7 @@ defmodule PassiveSupport.Stream do
         {99, "ab"}
       ]
   """
-  @spec with_memo(Enumerable.t, any, function, boolean) :: Stream.t
+  @spec with_memo(Enumerable.t, any, (Stream.element(), Stream.acc() -> Stream.acc()), boolean) :: Enumerable.t
   def with_memo(enum, accumulator, fun, evaluate_first \\ true) do
     Stream.transform(enum, accumulator, fn item, acc ->
       new = fun.(item, acc)

--- a/lib/passive_support/ext/logging.ex
+++ b/lib/passive_support/ext/logging.ex
@@ -1,0 +1,116 @@
+defmodule PassiveSupport.Logging do
+  @moduledoc """
+  Helper functions for logging and inspecting.
+
+  These functions serve two primary purposes:
+
+  1. To keep outputs colorized even when they're sent to Logger,
+  2. To keep `IO.inspect` and `Kernel.inspect` from truncating away data
+     you might need if you intend, e.g., to save a function's return
+     as fixture data for debugging purposes
+  """
+
+  import Kernel, except: [inspect: 1, inspect: 2]
+
+  @doc """
+  Sensible defaults for `IO.inspect` and `Kernel.inspect` when you want to see a value in its entirety
+  """
+  @spec inspect_opts :: [printable_limit: :infinity, limit: :infinity, width: 170, pretty: true]
+  def inspect_opts do
+    [
+      printable_limit: :infinity,
+      limit: :infinity,
+      width: 170,
+      pretty: true
+    ]
+  end
+
+  @doc """
+  Pretty good, pretty pretty, color choices for inspected data
+  """
+  @spec coloration_opts ::
+    {:syntax_colors, [number: :yellow, string: :green, list: :light_magenta,
+      map: :light_cyan, atom: :light_blue, tuple: :"[:black_background, :white]",
+      regex: :"[:cyan_background, :light_yellow]"
+    ]}
+  def coloration_opts do
+    {:syntax_colors, [number: :yellow, string: :green, list: :light_magenta,
+      map: :light_cyan, atom: :light_blue, tuple: [:black_background, :white],
+      regex: [:cyan_background, :light_yellow]
+    ]}
+  end
+
+  @doc """
+  Sensible option defaults for logging information to stdout
+  """
+  @spec logger_opts :: [
+    syntax_colors: [number: :yellow, string: :green, list: :light_magenta,
+        map: :light_cyan, atom: :light_blue, tuple: :"[:black_background, :white]",
+        regex: :"[:cyan_background, :light_yellow]"
+      ],
+    printable_limit: :infinity, limit: :infinity, width: 170, pretty: true
+  ]
+  def logger_opts do
+    [coloration_opts() | inspect_opts()]
+  end
+
+  @doc """
+  calls `Kernel.inspect/2` on `item` with `logger_opts/0`.
+
+  If you wish to overwrite some portion of the `opts` send to `inspect`,
+  consider calling `Kernel.inspect` and passing `Utils.logger_opts() ++
+  overwrites` as your `opts` instead of calling this function.
+  """
+  def inspect(item, to_log \\ false) do
+    Kernel.inspect(item, if(to_log, do: logger_opts(), else: inspect_opts()))
+  end
+
+  require Logger
+  def info(item \\ nil, label \\ nil) do
+    if label, do: Logger.info([label | ":"])
+    if item, do: Logger.info(inspect(item))
+    item
+  end
+
+  def debug(item \\ nil, label \\ nil) do
+    if label, do: Logger.debug([label | ":"])
+    if item, do: Logger.debug(inspect(item))
+    item
+  end
+
+  def warn(item \\ nil, label \\ nil) do
+    if label, do: Logger.warn([label | ":"])
+    if item, do: Logger.warn(inspect(item))
+    item
+  end
+
+  def alert(item \\ nil, label \\ nil) do
+    if label, do: Logger.alert([label | ":"])
+    if item, do: Logger.alert(inspect(item))
+    item
+  end
+
+  def critical(item \\ nil, label \\ nil) do
+    if label, do: Logger.critical([label | ":"])
+    if item, do: Logger.critical(inspect(item))
+    item
+  end
+
+  def emergency(item \\ nil, label \\ nil) do
+    if label, do: Logger.emergency([label | ":"])
+    if item, do: Logger.emergency(inspect(item))
+    item
+  end
+
+  def error(item \\ nil, label \\ nil) do
+    if label, do: Logger.error([label | ":"])
+    if item, do: Logger.error(inspect(item))
+    item
+  end
+
+  def notice(item \\ nil, label \\ nil) do
+    if label, do: Logger.notice([label | ":"])
+    if item, do: Logger.notice(inspect(item))
+    item
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule PassiveSupport.Mixfile do
   defp deps do
     [
       {:benchee, "~> 1.0.1", only: :dev},
-      {:ex_doc, ">= 0.0.0"}
+      {:ex_doc, "~> 0.24.1", only: :dev}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -23,8 +23,8 @@ defmodule PassiveSupport.Mixfile do
   end
 
   def extra_apps(:test), do: extra_apps(:dev)
-  def extra_apps(:dev), do: [:iex | [:os_mon | extra_apps(:prod)]]
-  def extra_apps(_), do: [:logger, :runtime_tools]
+  def extra_apps(:dev), do: [:iex | extra_apps(:staging)]
+  def extra_apps(_), do: [:logger]
 
   # Dependencies can be Hex packages:
   #

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "benchee": {:hex, :benchee, "1.0.1", "66b211f9bfd84bd97e6d1beaddf8fc2312aaabe192f776e8931cb0c16f53a521", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm", "3ad58ae787e9c7c94dd7ceda3b587ec2c64604563e049b2a0e8baafae832addb"},
+  "cpu_util": {:hex, :cpu_util, "0.5.1", "184b2ae00f372939eb387c5c6d92d8f68d54628d400a1ee681dff577d498545b", [:mix], [], "hexpm", "f169baef5572a4747da0f3f6bc8b185011bd23288fcacb631a8521f2c54cb6fd"},
   "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.12", "b245e875ec0a311a342320da0551da407d9d2b65d98f7a9597ae078615af3449", [:mix], [], "hexpm", "711e2cc4d64abb7d566d43f54b78f7dc129308a63bc103fbd88550d2174b3160"},
   "ex_doc": {:hex, :ex_doc, "0.24.1", "15673de99154f93ca7f05900e4e4155ced1ee0cd34e0caeee567900a616871a4", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "07972f17bdf7dc7b5bd76ec97b556b26178ed3f056e7ec9288eb7cea7f91cce2"},


### PR DESCRIPTION
- `Integer.exponential/2` is now tail-recursive
  - it is also redundant past the impending release of Elixir v1.12.0. Maybe.
- `PassiveSupport.Logging` has been pulled in from another project
- `Stream.with_memo`'s memoization function now has well-defined types
- `:os_mon` and `:runtime_tools` don't need to be run alongside the project
- `@doc since: ...` annotations for `Range`